### PR TITLE
Longer context training

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,20 @@ idea that the model is just memorizing the output: if it's correctly solving a
 large percentage of the nets, it must have learned to generally apply an
 underlying pattern.
 
-For gpt-3.5-turbo, we train on 2000 randomly generated nets, and use a
-validation set also of 2000. 2k samples appears to be good enough to get very
-close to perfect performance at any size in the training range; originally we
-trained on 200 samples, which provided near-perfect performance on <10 token
-nets but could sometimes struggle with ones approaching 21 tokens. 2000 samples
-is still far below the 5 trillion valid 21-token inputs, so the model isn't
-memorizing the outputs, it's just getting better at applying the pattern it's
-learned.
+For gpt-3.5-turbo, we train on 2000 randomly generated nets of up to 21 tokens
+and 30 long-context nets (interaction nets with 40-100 tokens), and use a
+validation set of 300 randomly generated nets and once again 30 long-context
+ones. 2k random samples appears to be good enough to get very close to perfect
+performance at any size in the training range; originally we trained on 200
+samples, which provided near-perfect performance on <10 token nets but could
+sometimes struggle with ones approaching 21 tokens. 2000 samples is still far
+below the 5 trillion valid 21-token inputs, so the model isn't memorizing the
+outputs, it's just getting better at applying the pattern it's learned.
 
-For Mistral, we do the same except on 3k samples each. Fewer might work too, it
-just takes an hour on my 4090 to train the LoRA so I haven't tried other sample
-sizes, and I figured it might need a small boost compared to gpt-3.5-turbo
-since it's a much smaller model.
+For Mistral, we do the same except we train on 2.5k random samples instead of
+2k. Fewer might work too, it just takes an hour on my 4090 to train the LoRA so
+I haven't tried other sample sizes, and I figured it might need a small boost
+of extra data compared to gpt-3.5-turbo since it's a much smaller model.
 
 Rather than using the `#A A# #B B#` notation Taelin originally used, we just
 use `A B C D` as tokens, to avoid possible model tokenization issues.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Finally, create an ollama model from the Modelfile in this repo:
 
 ```bash
 cd /path/to/clevergpt
-ollama create clevergpt-mistral ./Modelfile
+ollama create clevergpt-mistral -f ./Modelfile
 ```
 
 If ollama isn't already running, run:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ below the 5 trillion valid 21-token inputs, so the model isn't memorizing the
 outputs, it's just getting better at applying the pattern it's learned.
 
 For Mistral, we do the same except we train on 2.5k random samples instead of
-2k. Fewer might work too, it just takes an hour on my 4090 to train the LoRA so
-I haven't tried other sample sizes, and I figured it might need a small boost
-of extra data compared to gpt-3.5-turbo since it's a much smaller model.
+2k. Fewer might work too, it just takes an hour and a half on my 4090 to train
+the LoRA so I haven't tried other sample sizes, and I figured it might need a
+small boost of extra data compared to gpt-3.5-turbo since it's a much smaller
+model.
 
 Rather than using the `#A A# #B B#` notation Taelin originally used, we just
 use `A B C D` as tokens, to avoid possible model tokenization issues.

--- a/data/dataset.yaml
+++ b/data/dataset.yaml
@@ -48,8 +48,8 @@ gradient_checkpointing: true
 
 sequence_len: 8192
 
-gpu_memory_limit: 20GiB
-micro_batch_size: 2
+gpu_memory_limit: 22GiB
+micro_batch_size: 1
 gradient_accumulation_steps: 4
 warmup_steps: 10
 logging_steps: 1

--- a/finetune.ts
+++ b/finetune.ts
@@ -4,7 +4,7 @@ import path from "path";
 import fs from "fs/promises";
 import { createReadStream } from "fs";
 import OpenAI from "openai";
-import { trainingSample } from ".";
+import { generate } from ".";
 tmp.setGracefulCleanup();
 
 export const openai = new OpenAI({});
@@ -83,16 +83,8 @@ function prepareSample(sample: { prompt: string, output: string }): Message[] {
   ];
 }
 
-const validation: Message[][] = [];
-const training: Message[][] = [];
-for(let i = 0; i < SAMPLES; i++) {
-  validation.push(prepareSample(trainingSample()));
-  training.push(prepareSample(trainingSample()));
-}
-
-// Teach it what to do with the degenerate case of single-token programs
-training.push(prepareSample(trainingSample(1)));
-validation.push(prepareSample(trainingSample(1)));
+const validation = generate(SAMPLES, prepareSample);
+const training = generate(SAMPLES, prepareSample);
 
 createFinetune(
   "clevergpt",

--- a/finetune.ts
+++ b/finetune.ts
@@ -9,7 +9,8 @@ tmp.setGracefulCleanup();
 
 export const openai = new OpenAI({});
 
-const SAMPLES = 2000;
+const TRAINING_SAMPLES = 2000;
+const EVAL_SAMPLES = 400;
 
 async function createFinetune(
   filename: string,
@@ -83,8 +84,8 @@ function prepareSample(sample: { prompt: string, output: string }): Message[] {
   ];
 }
 
-const validation = generate(SAMPLES, prepareSample);
-const training = generate(SAMPLES, prepareSample);
+const validation = generate(EVAL_SAMPLES, prepareSample);
+const training = generate(TRAINING_SAMPLES, prepareSample);
 
 createFinetune(
   "clevergpt",

--- a/generate-lora-data.ts
+++ b/generate-lora-data.ts
@@ -1,7 +1,8 @@
 import * as fs from "fs/promises";
 import { generate } from ".";
 
-const SAMPLES = 3000;
+const TRAINING_SAMPLES = 2500;
+const EVAL_SAMPLES = 300;
 
 type Instruction = {
   instruction: string,
@@ -15,8 +16,8 @@ function prepareSample(sample: { prompt: string, output: string }): Instruction 
   };
 }
 
-const validation = generate(SAMPLES, prepareSample);
-const training = generate(SAMPLES, prepareSample);
+const validation = generate(EVAL_SAMPLES, prepareSample);
+const training = generate(TRAINING_SAMPLES, prepareSample);
 
 async function write() {
   await fs.writeFile("data/training.jsonl", training.map(d => JSON.stringify(d)).join("\n"));

--- a/generate-lora-data.ts
+++ b/generate-lora-data.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs/promises";
-import { trainingSample } from ".";
+import { generate } from ".";
 
 const SAMPLES = 3000;
 
@@ -14,16 +14,9 @@ function prepareSample(sample: { prompt: string, output: string }): Instruction 
     output: sample.output,
   };
 }
-const validation: Instruction[] = [];
-const training: Instruction[] = [];
-for(let i = 0; i < SAMPLES; i++) {
-  validation.push(prepareSample(trainingSample()));
-  training.push(prepareSample(trainingSample()));
-}
 
-// Teach it what to do with the degenerate case of single-token programs
-training.push(prepareSample(trainingSample(1)));
-validation.push(prepareSample(trainingSample(1)));
+const validation = generate(SAMPLES, prepareSample);
+const training = generate(SAMPLES, prepareSample);
 
 async function write() {
   await fs.writeFile("data/training.jsonl", training.map(d => JSON.stringify(d)).join("\n"));

--- a/index.ts
+++ b/index.ts
@@ -128,10 +128,12 @@ export function generate<T>(
   // Teach it what to do with the degenerate case of single-token programs
   data.push(prepareSample(trainingSample(1)));
 
-  // Give it a few super long context ones
-  data.push(prepareSample(trainingSample(100)));
-  data.push(prepareSample(trainingSample(75)));
-  data.push(prepareSample(trainingSample(50)));
+  // Give it a 30 super long context ones
+  for(let i = 9; i >= 0; i--) {
+    data.push(prepareSample(trainingSample(100 - i)));
+    data.push(prepareSample(trainingSample(75 - i)));
+    data.push(prepareSample(trainingSample(50 - i)));
+  }
 
   return data;
 }


### PR DESCRIPTION
This refactors the training data generation to add 30 long-context (50-100 token) examples. In my testing on Mistral, this allows it to solve 30-token programs pretty reliably, and solve 40-token programs around ~50% of the time (non-rigorous calculation, just what it seems like). Very long programs are still beyond its reach for now, although I suspect more training samples would improve perf.

I tested a smaller variant of this on gpt-3.5-turbo, and it worked in terms of getting reliable 30-token solves. I haven't tried the full set since I was getting tired of paying $12/run, but I'll probably try to get Mistral a bit better and then do a final gpt-3.5-turbo run since the latter generally has better performance (which makes sense, since it's a much larger model).